### PR TITLE
Update deploy.ts

### DIFF
--- a/src/services/deploy.ts
+++ b/src/services/deploy.ts
@@ -177,7 +177,7 @@ export class DeploySource {
         if(vscode.window.activeTextEditor) {
             const filePath = vscode.window.activeTextEditor.document.uri.fsPath;
             // Check if this is a static resource
-            if(filePath.indexOf('/staticresources/') !== -1) {
+            if(filePath.indexOf('/staticresources/') !== -1 || filePath.indexOf('\\staticresources\\') !== -1) {
                 fileSupported = true;
             } else {
                 //At this point only few file types are supported for auto save


### PR DESCRIPTION
The command "vscode.window.activeTextEditor.document.uri.fsPath" returns backslashes when working in Windows (ex. "c:\Project\force-app\main\default\staticresources\filename.js").