### PR TITLE
Patch 3: File path parsing for Windows fixed

### DIFF
--- a/src/services/deploy.ts
+++ b/src/services/deploy.ts
@@ -175,9 +175,9 @@ export class DeploySource {
     private static supportedFileForDeploy() : boolean {
         let fileSupported = false;
         if(vscode.window.activeTextEditor) {
-            const filePath = vscode.window.activeTextEditor.document.uri.fsPath;
+            const filePath = vscodeCore_1.VSCodeCore.getFsPath();
             // Check if this is a static resource
-            if(filePath.indexOf('/staticresources/') !== -1 || filePath.indexOf('\\staticresources\\') !== -1) {
+            if(filePath.indexOf('/staticresources/') !== -1) {
                 fileSupported = true;
             } else {
                 //At this point only few file types are supported for auto save

--- a/src/services/findMetadataType.ts
+++ b/src/services/findMetadataType.ts
@@ -12,7 +12,7 @@ export class Metadata {
     constructor(filepath: string) {
         this.filepath = filepath;
         this.directory = path.basename(path.dirname(path.dirname(this.filepath)));
-        this.isstaticresource = (filepath.indexOf('/staticresources/') === -1 || filepath.indexOf('\\staticresources\\') === -1 )? false : true;
+        this.isstaticresource = filepath.indexOf('/staticresources/') === -1 ? false : true;
     }
 
     public getMetadataType(): MetadataType {


### PR DESCRIPTION
Static resource detection logic used in findMetadataType.ts was returning incorrect result. Discovered that Windows to Unix file parsing was already performed in method getFsPath() [vscodeCore.ts:33]. Updated deploy.ts to use existing class for file path parsing. Reverted findMetadataType.ts to previous version (0.3.8). 